### PR TITLE
Changed init from nextTick to DOMContentLoaded

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -9,7 +9,7 @@
 >
     <div
         x-data="{ state: $wire.entangle('{{ $getStatePath() }}') }"
-        x-init="$nextTick(() => {
+        x-init="document.addEventListener('DOMContentLoaded', () => {
             tinymce.init({
                 target: $refs.tinymce,
                 language: '{{ $getInterfaceLanguage() }}',


### PR DESCRIPTION
Resolves issue where JS error shows tinyMce is not created, on slower-loading environments.