### PR TITLE
Revert init from DOMContentLoaded to nextTick

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -9,7 +9,7 @@
 >
     <div
         x-data="{ state: $wire.entangle('{{ $getStatePath() }}') }"
-        x-init="document.addEventListener('DOMContentLoaded', () => {
+        x-init="$nextTick(() => {
             tinymce.init({
                 target: $refs.tinymce,
                 language: '{{ $getInterfaceLanguage() }}',


### PR DESCRIPTION
Using DOMContentLoaded prevent rendering Editor in simple resource