### PR TITLE
Add - custom_config support for tinymce configurations

### DIFF
--- a/config/filament-forms-tinyeditor.php
+++ b/config/filament-forms-tinyeditor.php
@@ -26,6 +26,38 @@ return [
             'plugins' => 'autoresize template',
             'toolbar' => 'template',
         ],
+        /*
+        |--------------------------------------------------------------------------
+        | Custom Configs
+        |--------------------------------------------------------------------------
+        |
+        | If you want to add custom configurations to directly tinymce
+        | You can use custom_configs key as an array
+        |
+        */
+
+        /*
+          'default' => [
+            'plugins' => 'advlist autoresize codesample directionality emoticons fullscreen hr image imagetools link lists media table toc wordcount',
+            'toolbar' => 'undo redo removeformat | formatselect fontsizeselect | bold italic | rtl ltr | alignjustify alignright aligncenter alignleft | numlist bullist | forecolor backcolor | blockquote table toc hr | image link media codesample emoticons | wordcount fullscreen',
+            'custom_configs' => [
+                'allow_html_in_named_anchor' => true,
+                'link_default_target' => '_blank',
+                'codesample_global_prismjs' => true,
+                'image_advtab' => true,
+                'image_class_list' => [
+                  [
+                    'title' => 'None',
+                    'value' => '',
+                  ],
+                  [
+                    'title' => 'Fluid',
+                    'value' => 'img-fluid',
+                  ],
+              ],
+            ]
+        ],
+        */
 
     ],
 

--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -66,7 +66,8 @@
                                     putCursorToEnd();
                                 }
                             });
-                        }
+                        },
+                        {{ $getCustomConfigs() }}
                     })
                     initialized = true
                 }

--- a/src/Components/TinyEditor.php
+++ b/src/Components/TinyEditor.php
@@ -169,4 +169,13 @@ class TinyEditor extends Field implements Contracts\HasFileAttachments
 
         return json_encode(config('filament-forms-tinyeditor.templates.'.$this->template, []));
     }
+
+    public function getCustomConfigs(): string
+    {
+        if (config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs')) {
+            return rtrim(ltrim(json_encode(config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs')), "{"), "}");
+        }
+
+        return "";
+    }
 }


### PR DESCRIPTION
Added - `custom_configs` key example to `filament-forms-tinyeditor`
Added - `customConfigs()` method to `TinyEditor.php` for getting custom_config key from `filament-forms-tinyeditor`


> Now you can add custom configs inside laravel config file if you need to add specific custom configuration directly inside tinymce.init function.

Eg.
```php
'default' => [
            'plugins' => 'image', // ...
            'toolbar' => 'image', // ...
            'custom_configs' => [
                'custom_config' => true, // this will be converted for tinymce.init func.
            ]
],
 ```

```js
 tinymce.init({
   "custom_config": true
 })
 ```
