### PR TITLE
Fix merge custom configs

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -83,7 +83,7 @@
                                 }
                             });
                         },
-                        {{ $getCustomConfigs() }}
+                        ...{{ $getCustomConfigs() }}
                     });
                     initialized = true;
                 }

--- a/src/Components/TinyEditor.php
+++ b/src/Components/TinyEditor.php
@@ -175,7 +175,7 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained, Cont
     public function getCustomConfigs(): string
     {
         if (config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs')) {
-            return rtrim(ltrim(json_encode(config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs')), '{'), '}');
+            return json_encode(config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs'));
         }
 
         return '';


### PR DESCRIPTION
When there are several keys at the same level in the custom configuration (TinyMCE configuration is sometimes at the same level), the rtrim and ltrim functions break the JSON array.
I fixed this by removing the functions and merging the custom config with spread syntax.

I created the Filament discord topic here for more information.
Here: https://discord.com/channels/883083792112300104/922411184962035723/1042768313484316802

Example array
```
'custom_configs' => [
	'style_formats'=> [
		['title' => 'Inline', 'items' => [
			[ 'title' => 'Bold', 'format' => 'bold' ],
			[ 'title' => 'Italic', 'format' => 'italic' ],
		]],
		['title'=> 'Headings', 'items'=> [
			[ 'title' => 'H1', 'format' => 'h1' ],
			[ 'title' => 'H2', 'format' => 'h2' ],
		]],
		['title' => 'Buttons', 'items' => [
			[ 'title' => 'Red', 'format' => 'btnPrimary' ],
		]],
	],
	'formats' => [
		'btnPrimary' => [ 'selector' => 'a', 'classes' => [ 'btn', 'btn-primary' ] ],
	],
]
```
![1](https://user-images.githubusercontent.com/12073014/202516610-f1cbb171-d623-4e8b-a073-1753d6bfb440.png)
![image](https://user-images.githubusercontent.com/12073014/202516619-b93c7203-4057-49da-8e2e-3d0e509782b5.png)

Thanks !