### PR TITLE
Fix custom configs when custom_configs is empty

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -83,7 +83,7 @@
                                 }
                             });
                         },
-                        ...{{ $getCustomConfigs() }}
+                        {{ $getCustomConfigs() }}
                     });
                     initialized = true;
                 }

--- a/src/Components/TinyEditor.php
+++ b/src/Components/TinyEditor.php
@@ -175,7 +175,7 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained, Cont
     public function getCustomConfigs(): string
     {
         if (config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs')) {
-            return json_encode(config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs'));
+            return '...' . json_encode(config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs'));
         }
 
         return '';


### PR DESCRIPTION
This is following yesterday's patch, I didn't take into account the absence of the custom_config. it's fixed with this commit.

More information here: https://discord.com/channels/883083792112300104/922411184962035723/1043207496518606908