### PR TITLE
Theme based body_class

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -24,6 +24,7 @@
                         language: '{{ $getInterfaceLanguage() }}',
                         skin: typeof theme != 'undefined' ? theme : 'light',
                         content_css: this.skin === 'dark' ? 'dark' : 'default',
+                        body_class: theme === 'dark' ? 'dark' : 'light',
                         max_height: {{ $getMaxHeight() }},
                         min_height: {{ $getMinHeight() }},
                         menubar: {{ $getShowMenuBar() ? 'true' : 'false' }},


### PR DESCRIPTION
**body_class** property based on Filament's dark/light mode, applied to iframe's body element for separate theming via **content_style**.
Example:
'content_style' => 'body.dark {background-color: #12161c;} body.light {background-color: #e5fef1;}';