### PR TITLE
Fix duplicate tinymce library

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -129,9 +129,3 @@
         @endunless
     </div>
 </x-dynamic-component>
-
-@once
-    @push('scripts')
-        <script src="{{ asset('vendor/filament-forms-tinyeditor/tinymce/tinymce.min.js') }}"></script>
-    @endpush
-@endonce


### PR DESCRIPTION
It'slready included via service provider 
`'filament-forms-tinyeditor' => asset('vendor/filament-forms-tinyeditor/tinymce/tinymce.min.js'),`

Only difference is that filament script uses `defer` if that makes a difference and need to remove the other?
```html
<script defer src="https://example.com/vendor/filament-forms-tinyeditor/tinymce/tinymce.min.js"></script>
                    
<script src="https://example.com/vendor/filament-forms-tinyeditor/tinymce/tinymce.min.js"></script>
```