### PR TITLE
Add hook for removing tinymce instance

### DIFF
--- a/resources/dist/js/app.js
+++ b/resources/dist/js/app.js
@@ -4,6 +4,13 @@ document.addEventListener('DOMContentLoaded', function () {
         'filament-forms-repeater-component',
     ];
 
+    Livewire.hook('element.removed', (el, component) => {
+        if (el && el.getAttribute('x-ref') === 'tinymce') {
+            tinymce.execCommand('mceRemoveEditor', false, el.id)
+            window.tinySettingsCopy = window.tinySettingsCopy.filter(tinySetting => tinySetting.id !== el.id);
+        }
+    });
+
     Livewire.hook('element.updated', (el) => {
         if (!window.tinySettingsCopy) {
             return;


### PR DESCRIPTION
Fix an issue when using TinyEditor inside a repeater and you add/remove the repeater item. 

```php
Forms\Components\Repeater::make('test')
  ->schema([
      TinyEditor::make('editor')
  ])
```

https://github.com/mohamedsabil83/filament-forms-tinyeditor/assets/533658/86d664a9-6a50-4dd3-a0a7-1a9a842caba1

With fix

https://github.com/mohamedsabil83/filament-forms-tinyeditor/assets/533658/6c0c5a8f-91f5-460f-a26c-8b8998def262


