### PR TITLE
Fixed version for Filament 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Light mode                           | Dark mode
 You can install the package via composer:
 
 ```bash
-composer require mohamedsabil83/filament-forms-tinyeditor
+composer require mohamedsabil83/filament-forms-tinyeditor:"^1.0"
 ```
 
 Next, publish the asset by run the following:


### PR DESCRIPTION
When I try to install the plugin on an old version of Filament, version 2 is installed by default. As a result, I get an error.