### PR TITLE
Replace double quotes with single quotes

### DIFF
--- a/src/Components/TinyEditor.php
+++ b/src/Components/TinyEditor.php
@@ -332,7 +332,12 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained, Cont
     public function getCustomConfigs(): string
     {
         if (config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs')) {
-            return '...'.json_encode(config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs'));
+
+            $jsonString = json_encode(config('filament-forms-tinyeditor.profiles.'.$this->profile.'.custom_configs'));
+            // Replace double quotes with single quotes
+            $jsonString = str_replace('"', "'", $jsonString);
+
+            return '...'.$jsonString;
         }
 
         return '';


### PR DESCRIPTION
Addressed issue related to the use of double quotes with Inertia or when passing a configuration as a value to HTML attributes.