### PR TITLE
Fix initialisation of deleted editors

### DIFF
--- a/resources/dist/js/tiny-editor.js
+++ b/resources/dist/js/tiny-editor.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', function () {
     })
 
     const removeEditors = debounce(() => {
+        window.tinySettingsCopy = window.tinySettingsCopy.filter((obj) => document.getElementById(obj.id));
         window.tinySettingsCopy.forEach(i => tinymce.execCommand('mceRemoveEditor', false, i.target.id));
     }, 50);
 

--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -49,7 +49,10 @@
                         if(!window.tinySettingsCopy) {
                             window.tinySettingsCopy = [];
                         }
-                        window.tinySettingsCopy.push(editor.settings);
+
+                        if (!window.tinySettingsCopy.some(obj => obj.id === editor.settings.id)) {
+                            window.tinySettingsCopy.push(editor.settings);
+                        }
 
                         editor.on('blur', function(e) {
                             state = editor.getContent()


### PR DESCRIPTION
This PR fixes 2 problems that occurs mainly when using repeaters or builders.

The first commit fixes the following error that occurs after removing a block containing a tinyeditor.
![image](https://github.com/mohamedsabil83/filament-forms-tinyeditor/assets/5481247/a3c467a5-58bb-445d-88d6-f3782d2d77db)

The second commit prevent the tinySettingsCopy array from growing up after each livewire redraw.