### PR TITLE
feat: enable file uploads on links and media

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -44,6 +44,29 @@
                             })
                         })
                     },
+                    file_picker_callback: (cb, value, meta) => {
+                        const input = document.createElement('input');
+                        input.setAttribute('type', 'file');
+                        input.addEventListener('change', (e) => {
+                            const file = e.target.files[0];
+                            const reader = new FileReader();
+                            reader.addEventListener('load', () => {
+                                console.log('{{ $getStatePath() }}')
+                                $wire.upload(`componentFileAttachments.{{ $getStatePath() }}`, file, () => {
+                                    $wire.getFormComponentFileAttachmentUrl('{{ $getStatePath() }}').then((url) => {
+                                        if (!url) {
+                                            cb('{{ __('Error uploading file') }}')
+                                            return
+                                        }
+                                        cb(url)
+                                    })
+                                })
+                            });
+                            reader.readAsDataURL(file);
+                        });
+
+                        input.click();
+                    },
                     automatic_uploads: true,
                     templates: {{ $getTemplate() }},
                     setup: function(editor) {


### PR DESCRIPTION
this PR enable the "upload" button on "links" and "media"

According  to TinyMCE documentation for enable this functionality you must declare "file_picker_callback" function on tinyEditor initialization.

more info:
[https://www.tiny.cloud/docs/tinymce/6/image/#file_picker_callback](https://www.tiny.cloud/docs/tinymce/6/image/#file_picker_callback)

![image](https://github.com/mohamedsabil83/filament-forms-tinyeditor/assets/61713673/cbf85bbb-04e6-49ab-b405-229d00ddf205)
