### PR TITLE
Add Laravel 12 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,15 +14,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3, 8.2, 8.1 ]
-        laravel: [ 11.*, 10.* ]
+        php: [ 8.4, 8.3, 8.2, 8.1 ]
+        laravel: [ 12.*, 11.*, 10.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
+          - laravel: 12.*
+            testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
         exclude:
+          - laravel: 12.*
+            php: 8.1
           - laravel: 11.*
             php: 8.1
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "mohamedsabil83/filament-forms-tinyeditor",
     "description": "A TinyMce editor component for Filament",
+    "license": "MIT",
     "keywords": [
         "laravel",
         "filament",
@@ -8,8 +9,6 @@
         "tinyeditor",
         "tinymce"
     ],
-    "homepage": "https://github.com/mohamedsabil83/filament-forms-tinyeditor",
-    "license": "MIT",
     "authors": [
         {
             "name": "MohamedSabil83",
@@ -17,25 +16,28 @@
             "role": "Developer"
         }
     ],
+    "homepage": "https://github.com/mohamedsabil83/filament-forms-tinyeditor",
     "require": {
         "php": "^8.1",
         "filament/forms": "^3.0",
-        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^9.0 || ^10.0 || ^11.0 || ^12.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.2",
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "8.0|^9.0",
+        "nunomaduro/collision": "^7.0 || ^8.0",
+        "orchestra/testbench": "8.0 || ^9.0 || ^10.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
         "spatie/laravel-ray": "^1.26"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Mohamedsabil83\\FilamentFormsTinyeditor\\": "src"
@@ -46,19 +48,12 @@
             "Mohamedsabil83\\FilamentFormsTinyeditor\\Tests\\": "tests"
         }
     },
-    "scripts": {
-        "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
-        "analyse": "vendor/bin/phpstan analyse",
-        "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/pint"
-    },
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "phpstan/extension-installer": true
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "laravel": {
@@ -67,6 +62,11 @@
             ]
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "scripts": {
+        "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
+        "analyse": "vendor/bin/phpstan analyse",
+        "format": "vendor/bin/pint",
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage"
+    }
 }


### PR DESCRIPTION
This pull request includes updates to the testing matrix in the GitHub Actions workflow and several modifications to the `composer.json` file to support the latest versions of PHP and Laravel. The most important changes include expanding the test matrix, updating dependencies, and reorganizing the `composer.json` file.

Updates to testing matrix:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L17-R29): Added PHP 8.4 and Laravel 12.* to the testing matrix, and excluded Laravel 12.* with PHP 8.1.

Modifications to `composer.json`:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R4-R40): Updated `illuminate/contracts`, `orchestra/testbench`, and `phpunit/phpunit` dependencies to include support for Laravel 12.* and PHP 8.4.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L49-R56): Reorganized the file to move `minimum-stability` and `prefer-stable` settings, and re-added the `scripts` section with commands for testing and code analysis. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L49-R56) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L70-R71)